### PR TITLE
Fix history charts ignoring latest fetched data

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -516,12 +516,10 @@ type dayData struct {
 	snapshot storage.StatsSnapshot
 }
 
-// collapseHistoryByDay reduces snapshots to one per local calendar day, returned
-// sorted ascending by date. The bot may store several snapshots per day
-// (on-demand refresh, /summary, /chart, daily scheduler); each day is represented
-// by its *latest* snapshot so the chart reflects the most recently fetched data —
-// in particular, the current day's bar shows the data the triggering request just
-// fetched.
+// collapseHistoryByDay reduces snapshots to one per UTC calendar day, sorted
+// ascending by date. The bot may store several snapshots per day (refresh,
+// /summary, /chart, daily scheduler); each day keeps its latest snapshot so the
+// current day's bar reflects the data the triggering request just fetched.
 func collapseHistoryByDay(snapshots []storage.StatsSnapshot) []dayData {
 	dailyMap := make(map[string]storage.StatsSnapshot)
 	for _, s := range snapshots {
@@ -562,7 +560,6 @@ func (b *Bot) renderHistoryChart(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("no history data available")
 	}
 
-	// Collapse each day to a single bar (see collapseHistoryByDay).
 	days := collapseHistoryByDay(snapshots)
 
 	// Keep only the most recent 14 days (guards the calendar/time-of-day edge of

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -510,6 +510,36 @@ func (b *Bot) renderRadarChart(data *service.StatsData) ([]byte, error) {
 	return buf, nil
 }
 
+// dayData is one day's representative snapshot for the history chart.
+type dayData struct {
+	date     string
+	snapshot storage.StatsSnapshot
+}
+
+// collapseHistoryByDay reduces snapshots to one per local calendar day, returned
+// sorted ascending by date. The bot may store several snapshots per day
+// (on-demand refresh, /summary, /chart, daily scheduler); each day is represented
+// by its *latest* snapshot so the chart reflects the most recently fetched data —
+// in particular, the current day's bar shows the data the triggering request just
+// fetched.
+func collapseHistoryByDay(snapshots []storage.StatsSnapshot) []dayData {
+	dailyMap := make(map[string]storage.StatsSnapshot)
+	for _, s := range snapshots {
+		key := s.Timestamp.Format("2006-01-02")
+		existing, ok := dailyMap[key]
+		if !ok || s.Timestamp.After(existing.Timestamp) {
+			dailyMap[key] = s
+		}
+	}
+
+	days := make([]dayData, 0, len(dailyMap))
+	for k, v := range dailyMap {
+		days = append(days, dayData{date: k, snapshot: v})
+	}
+	slices.SortFunc(days, func(a, b dayData) int { return cmp.Compare(a.date, b.date) })
+	return days
+}
+
 // renderHistoryChart generates a bar chart PNG showing total task age over the
 // last 14 days (one bar per day).
 func (b *Bot) renderHistoryChart(ctx context.Context) ([]byte, error) {
@@ -532,28 +562,8 @@ func (b *Bot) renderHistoryChart(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("no history data available")
 	}
 
-	// Group by day. The bot may store several snapshots per day (on-demand
-	// refresh, /summary, /chart, daily scheduler); collapse each day to a single
-	// bar using the lowest total age recorded that day.
-	type dayData struct {
-		date     string
-		snapshot storage.StatsSnapshot
-	}
-	dailyMap := make(map[string]storage.StatsSnapshot)
-	for _, s := range snapshots {
-		key := s.Timestamp.Format("2006-01-02")
-		existing, ok := dailyMap[key]
-		if !ok || s.GlobalStats.TotalAge < existing.GlobalStats.TotalAge {
-			dailyMap[key] = s
-		}
-	}
-
-	// Sort days chronologically
-	days := make([]dayData, 0, len(dailyMap))
-	for k, v := range dailyMap {
-		days = append(days, dayData{date: k, snapshot: v})
-	}
-	slices.SortFunc(days, func(a, b dayData) int { return cmp.Compare(a.date, b.date) })
+	// Collapse each day to a single bar (see collapseHistoryByDay).
+	days := collapseHistoryByDay(snapshots)
 
 	// Keep only the most recent 14 days (guards the calendar/time-of-day edge of
 	// the cutoff so there are never more than 14 bars).

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -1,0 +1,53 @@
+package bot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/uchr/ToDoInfo/internal/storage"
+)
+
+func snap(ts time.Time, totalAge int) storage.StatsSnapshot {
+	return storage.StatsSnapshot{
+		Timestamp:   ts,
+		GlobalStats: storage.GlobalStats{TotalAge: totalAge, TaskCount: 1},
+	}
+}
+
+// Regression: a day with several snapshots must be represented by its latest
+// snapshot, not the one with the lowest total age. Otherwise the chart ignores
+// the data a /chart or /summary request just fetched.
+func TestCollapseHistoryByDay_KeepsLatestPerDay(t *testing.T) {
+	day := time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC)
+	earlyLowAge := snap(day.Add(8*time.Hour), 100)  // earlier, lower total age
+	lateHighAge := snap(day.Add(20*time.Hour), 150) // latest snapshot of the day
+
+	// Order shuffled to confirm selection is by timestamp, not input order.
+	got := collapseHistoryByDay([]storage.StatsSnapshot{lateHighAge, earlyLowAge})
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 day, got %d", len(got))
+	}
+	if got[0].snapshot.GlobalStats.TotalAge != 150 {
+		t.Fatalf("expected latest snapshot (totalAge 150), got %d",
+			got[0].snapshot.GlobalStats.TotalAge)
+	}
+}
+
+func TestCollapseHistoryByDay_SortsAscendingByDate(t *testing.T) {
+	d1 := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	d2 := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	d3 := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+
+	got := collapseHistoryByDay([]storage.StatsSnapshot{snap(d3, 3), snap(d1, 1), snap(d2, 2)})
+
+	want := []string{"2026-06-20", "2026-06-21", "2026-06-22"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d days, got %d", len(want), len(got))
+	}
+	for i, w := range want {
+		if got[i].date != w {
+			t.Fatalf("day %d: expected %s, got %s", i, w, got[i].date)
+		}
+	}
+}

--- a/internal/cli/stats.go
+++ b/internal/cli/stats.go
@@ -473,7 +473,7 @@ func renderHistoricalCharts(points []storage.TimeSeriesPoint) {
 	labels := make([]string, len(points))
 
 	for i, point := range points {
-		ageData[i] = float64(point.MaxAge)
+		ageData[i] = float64(point.LatestAge)
 		labels[i] = point.Date.Format("01-02")
 	}
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -34,10 +34,12 @@ type GlobalStats struct {
 	TaskCount int `json:"task_count"`
 }
 
-// TimeSeriesPoint represents a data point in time series
+// TimeSeriesPoint represents a data point in time series. Each point is the
+// latest snapshot of its day (see GetTimeSeriesData), matching the bot's history
+// chart so the two never disagree on a day's value.
 type TimeSeriesPoint struct {
 	Date      time.Time `json:"date"`
-	MaxAge    int       `json:"max_age"`
+	LatestAge int       `json:"latest_age"`
 	TaskCount int       `json:"task_count"`
 }
 

--- a/internal/storage/sqlite_storage.go
+++ b/internal/storage/sqlite_storage.go
@@ -165,12 +165,16 @@ func (s *SQLiteStorage) GetHistory(ctx context.Context, from, to time.Time) ([]S
 	return snapshots, rows.Err()
 }
 
-// GetTimeSeriesData retrieves time series data for graphing.
+// GetTimeSeriesData retrieves time series data for graphing: one point per day,
+// carrying the values of that day's latest snapshot. The MAX(timestamp) aggregate
+// triggers SQLite's "bare column" rule — total_age and task_count are taken from
+// the row holding the day's maximum timestamp — so a day with several snapshots
+// reports its most recent one, consistent with the bot's history chart.
 func (s *SQLiteStorage) GetTimeSeriesData(ctx context.Context, days int) ([]TimeSeriesPoint, error) {
 	cutoff := time.Now().AddDate(0, 0, -days).UTC().Format(time.RFC3339)
 
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT date(timestamp) AS d, MAX(total_age), MAX(task_count)
+		`SELECT date(timestamp) AS d, total_age, task_count, MAX(timestamp)
 		 FROM snapshots
 		 WHERE timestamp > ?
 		 GROUP BY d
@@ -184,9 +188,9 @@ func (s *SQLiteStorage) GetTimeSeriesData(ctx context.Context, days int) ([]Time
 
 	var points []TimeSeriesPoint
 	for rows.Next() {
-		var dateStr string
-		var maxAge, taskCount int
-		if err := rows.Scan(&dateStr, &maxAge, &taskCount); err != nil {
+		var dateStr, latestTS string
+		var latestAge, taskCount int
+		if err := rows.Scan(&dateStr, &latestAge, &taskCount, &latestTS); err != nil {
 			return nil, fmt.Errorf("scan time series row: %w", err)
 		}
 		d, err := time.Parse("2006-01-02", dateStr)
@@ -195,7 +199,7 @@ func (s *SQLiteStorage) GetTimeSeriesData(ctx context.Context, days int) ([]Time
 		}
 		points = append(points, TimeSeriesPoint{
 			Date:      d,
-			MaxAge:    maxAge,
+			LatestAge: latestAge,
 			TaskCount: taskCount,
 		})
 	}

--- a/internal/storage/sqlite_storage_test.go
+++ b/internal/storage/sqlite_storage_test.go
@@ -135,16 +135,17 @@ func TestSQLiteStorage_GetTimeSeriesData(t *testing.T) {
 	// within an hour of UTC midnight would otherwise split today's pair.
 	now := time.Now().UTC().Truncate(24 * time.Hour).Add(12 * time.Hour)
 
-	// Two snapshots on the same day with different values
+	// Two snapshots on the same day. The earlier one has the higher total age, so
+	// MAX(total_age) and latest-snapshot disagree — this pins latest-per-day.
 	s.Store(ctx, StatsSnapshot{
 		Timestamp:   now.Add(-1 * time.Hour),
-		GlobalStats: GlobalStats{TotalAge: 50, TaskCount: 3},
-		ListAges:    todometrics.ListAges{TotalAge: 50},
+		GlobalStats: GlobalStats{TotalAge: 100, TaskCount: 5},
+		ListAges:    todometrics.ListAges{TotalAge: 100},
 	})
 	s.Store(ctx, StatsSnapshot{
 		Timestamp:   now,
-		GlobalStats: GlobalStats{TotalAge: 100, TaskCount: 5},
-		ListAges:    todometrics.ListAges{TotalAge: 100},
+		GlobalStats: GlobalStats{TotalAge: 80, TaskCount: 4},
+		ListAges:    todometrics.ListAges{TotalAge: 80},
 	})
 
 	// One snapshot yesterday
@@ -163,15 +164,15 @@ func TestSQLiteStorage_GetTimeSeriesData(t *testing.T) {
 	}
 
 	// First point is yesterday
-	if points[0].MaxAge != 30 {
-		t.Errorf("yesterday MaxAge = %d, want 30", points[0].MaxAge)
+	if points[0].LatestAge != 30 {
+		t.Errorf("yesterday LatestAge = %d, want 30", points[0].LatestAge)
 	}
-	// Second point is today — should be MAX(50, 100) = 100
-	if points[1].MaxAge != 100 {
-		t.Errorf("today MaxAge = %d, want 100", points[1].MaxAge)
+	// Second point is today — latest snapshot (age 80), NOT max(100, 80).
+	if points[1].LatestAge != 80 {
+		t.Errorf("today LatestAge = %d, want 80 (latest snapshot, not max)", points[1].LatestAge)
 	}
-	if points[1].TaskCount != 5 {
-		t.Errorf("today TaskCount = %d, want 5", points[1].TaskCount)
+	if points[1].TaskCount != 4 {
+		t.Errorf("today TaskCount = %d, want 4", points[1].TaskCount)
 	}
 }
 


### PR DESCRIPTION
## Problem

The bot's history chart collapsed each day to the snapshot with the **lowest total age**:

```go
if !ok || s.GlobalStats.TotalAge < existing.GlobalStats.TotalAge {
```

`/chart`, `/summary`, and the daily scheduler all refresh data before rendering and store a fresh snapshot. But if an earlier snapshot that same day had a lower total age, the min-of-day rule kept the *old* one — so the current day's bar ignored the data the request just fetched. (The radar chart was unaffected; it reads `GetLatest()` directly.)

## Fix

- Represent each day by its **latest** snapshot (by timestamp), extracted into a pure, unit-tested `collapseHistoryByDay` helper.
- Align `storage.GetTimeSeriesData` (the CLI `stats` charts), which aggregated with `MAX(total_age)` and would disagree with the bot whenever a day's latest snapshot wasn't its highest. Switched to latest-per-day via SQLite's bare-column rule (`MAX(timestamp)` selects the row) and renamed `TimeSeriesPoint.MaxAge` → `LatestAge` to match the new semantics.

## Tests

- New `internal/bot/bot_test.go`: `collapseHistoryByDay` keeps the latest snapshot per day (regression — the old min-of-day logic returns the wrong value) and sorts ascending.
- Updated `GetTimeSeriesData` test to a discriminating case (today's latest age 80 < earlier age 100) so it proves latest-per-day rather than max.
- `go build ./...` and `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)